### PR TITLE
Fix of the compare function used by Collection.sort() test

### DIFF
--- a/spec/suite/collection/collection.spec.js
+++ b/spec/suite/collection/collection.spec.js
@@ -211,7 +211,7 @@ describe("Collection", function() {
 
       var collection = new Collection({ data: ['Alan', 'Dave', 'betsy', 'carl'] });
       var result = collection.sort(function(a, b) {
-        return a < b;
+        return a < b ? 1 : (a > b ? -1 : 0);
       });
       expect(result.data()).toEqual(['carl', 'betsy', 'Dave', 'Alan']);
 


### PR DESCRIPTION
The previous version of the compare function was not consistent (it did not follow the requirements on the compare function), see https://tc39.github.io/ecma262/#sec-array.prototype.sort for details. The given test-case is too small to notice that on V8 (the default JavaScript engine of Node.js) but the test fails on an alternative JavaScript engine that I tried. You can see that the compare function is not correct by using it to sort larger arrays. For example, if you sort the letters of a well known sentence:
`"the quick brown fox jumps over the lazy dog".split('').sort((a,b) => a<b).join('')`
returns `"utyztuvxwogroknolohqjhmpsrifbdeecea        "` on Node.js 6.7.0. While `"the quick brown fox jumps over the lazy dog".split('').sort((a,b) => a<b ? 1 : (a>b ? -1 : 0)).join('')` returns the correct result `'zyxwvuuttsrrqpoooonmlkjihhgfeeedcba        '`.